### PR TITLE
URL schema standardized

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,16 +29,24 @@ Supported Caches
 ----------------
 Support currently exists for:
 
-* locmem (default): ``'locmem://[location][/location]'``
-* db: ``'db://cache_table[/prefix]'``
+* locmem (default): ``'locmem://[NAME]'``
+* db: ``'db://TABLE_NAME'``
 * dummy: ``'dummy://'``
-* file: ``'file:///path/to/file'``
-* memcached: ``'memcached://127.0.0.1:11211[/prefix]``
-* pymemcached: ``'pymemcached://127.0.0.1:11211[/prefix]'`` For use with the python-memcached library. Useful if you're using Ubuntu <= 10.04.
-* djangopylibmc: ``'djangopylibmc://127.0.0.1:11211[/prefix]'`` For use with SASL based setups such as Heroku.
-* redis: ``'redis://t@host:port/db[/prefix]'`` or ``'redis:///unix/path/to/socket/file.sock/db[/prefix]'`` For use with django-redis library.
-* hiredis ``'hiredis://host:port/db[/prefix]'`` or ``'hiredis:///unix/path/to/socket/file.sock/db[/prefix]'`` For use with django-redis library using
-  HiredisParser
+* file: ``'file:///PATH/TO/FILE'``
+* memcached: ``'memcached://HOST:PORT'`` [#memcache]_
+* pymemcached: ``'pymemcached://HOST:PORT'`` For use with the `python-memcached`_ library. Useful if you're using Ubuntu <= 10.04.
+* djangopylibmc: ``'djangopylibmc://HOST:PORT'`` For use with SASL based setups such as Heroku.
+* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[:DB]'`` or ``'redis:///PATH/TO/SOCKET[:DB]'`` For use with `django-redis`_.
+* hiredis ``'hiredis://[USER:PASSWORD@]HOST:PORT[:DB]'`` or ``'hiredis:///PATH/TO/SOCKET[:DB]'`` For use with django-redis library using HiredisParser.
+
+All cache urls support optional cache arguments by using a query string, e.g.: ``'memcached://HOST:PORT?key_prefix=site1'``. See the Django `cache arguments documentation`_.
+
+.. [#memcache] To specify multiple instances, separate the the ``HOST:PORT``` pair
+               by commas, e.g: ``'memcached://HOST1:PORT1,HOST2:PORT2``
+
+.. _django-redis: https://github.com/niwibe/django-redis
+.. _python-memcached: https://github.com/linsomniac/python-memcached
+.. _cache arguments documentation: https://docs.djangoproject.com/en/dev/topics/cache/#cache-arguments
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ Support currently exists for:
 * memcached: ``'memcached://HOST:PORT'`` [#memcache]_
 * pymemcached: ``'pymemcached://HOST:PORT'`` For use with the `python-memcached`_ library. Useful if you're using Ubuntu <= 10.04.
 * djangopylibmc: ``'djangopylibmc://HOST:PORT'`` For use with SASL based setups such as Heroku.
-* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[:DB]'`` or ``'redis:///PATH/TO/SOCKET[:DB]'`` For use with `django-redis`_.
-* hiredis ``'hiredis://[USER:PASSWORD@]HOST:PORT[:DB]'`` or ``'hiredis:///PATH/TO/SOCKET[:DB]'`` For use with django-redis library using HiredisParser.
+* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'redis:///PATH/TO/SOCKET[/DB]'`` For use with `django-redis`_.
+* hiredis ``'hiredis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'hiredis:///PATH/TO/SOCKET[/DB]'`` For use with django-redis library using HiredisParser.
 
 All cache urls support optional cache arguments by using a query string, e.g.: ``'memcached://HOST:PORT?key_prefix=site1'``. See the Django `cache arguments documentation`_.
 

--- a/tests.py
+++ b/tests.py
@@ -112,7 +112,7 @@ class TestMemcachedCache(Base):
 class TestRedisCache(Base):
     def setUp(self):
         super(TestRedisCache, self).setUp()
-        environ['CACHE_URL'] = 'redis://127.0.0.1:6379:0?key_prefix=site1'
+        environ['CACHE_URL'] = 'redis://127.0.0.1:6379/0?key_prefix=site1'
 
     def test_redis_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -131,7 +131,7 @@ class TestRedisCache(Base):
 class TestHiredisCache(Base):
     def setUp(self):
         super(TestHiredisCache, self).setUp()
-        environ['CACHE_URL'] = 'hiredis://127.0.0.1:6379:0?key_prefix=site1'
+        environ['CACHE_URL'] = 'hiredis://127.0.0.1:6379/0?key_prefix=site1'
 
     def test_hiredis_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -155,7 +155,7 @@ class TestHiredisCache(Base):
 class TestRedisCacheWithPassword(Base):
     def setUp(self):
         super(TestRedisCacheWithPassword, self).setUp()
-        environ['CACHE_URL'] = 'redis://:redispass@127.0.0.1:6379:0?key_prefix=site1'
+        environ['CACHE_URL'] = 'redis://:redispass@127.0.0.1:6379/0?key_prefix=site1'
 
     def test_redis_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -180,7 +180,7 @@ class TestRedisCacheWithPassword(Base):
 class TestRedisBothSocketCache(Base):
     def setUp(self):
         super(TestRedisBothSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'redis:///path/to/socket:1?key_prefix=site1'
+        environ['CACHE_URL'] = 'redis:///path/to/socket/1?key_prefix=site1'
 
     def test_socket_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -199,7 +199,7 @@ class TestRedisBothSocketCache(Base):
 class TestRedisDatabaseSocketCache(TestRedisBothSocketCache):
     def setUp(self):
         super(TestRedisDatabaseSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'redis:///path/to/socket:1'
+        environ['CACHE_URL'] = 'redis:///path/to/socket/1'
 
     def test_socket_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
@@ -223,7 +223,7 @@ class TestRedisPrefixSocketCache(TestRedisBothSocketCache):
 class TestHiredisDatabaseSocketCache(TestRedisDatabaseSocketCache):
     def setUp(self):
         super(TestHiredisDatabaseSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'hiredis:///path/to/socket:1'
+        environ['CACHE_URL'] = 'hiredis:///path/to/socket/1'
 
     def test_hiredis_url_sets_hiredis_parser(self):
         config = django_cache_url.config()

--- a/tests.py
+++ b/tests.py
@@ -88,7 +88,7 @@ class TestLocMemCache(Base):
 class TestMemcachedCache(Base):
     def setUp(self):
         super(TestMemcachedCache, self).setUp()
-        environ['CACHE_URL'] = 'memcached://127.0.0.1:11211/prefix'
+        environ['CACHE_URL'] = 'memcached://127.0.0.1:11211?key_prefix=site1'
 
     def test_memcached_url_returns_pylibmc_cache(self):
         location = 'django.core.cache.backends.memcached.PyLibMCCache'
@@ -101,18 +101,18 @@ class TestMemcachedCache(Base):
 
     def test_memcached_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], 'prefix')
+        assert_equals(config['KEY_PREFIX'], 'site1')
 
     def test_memcached_url_multiple_locations(self):
-        environ['CACHE_URL'] = 'memcached://127.0.0.1:11211,192.168.0.100:11211/prefix'
+        environ['CACHE_URL'] = 'memcached://127.0.0.1:11211,192.168.0.100:11211?key_prefix=site1'
         config = django_cache_url.config()
-        assert_equals(config['LOCATION'], ['127.0.0.1:11211', '192.168.0.100:11211'])
+        assert_equals(config['LOCATION'], '127.0.0.1:11211;192.168.0.100:11211')
 
 
 class TestRedisCache(Base):
     def setUp(self):
         super(TestRedisCache, self).setUp()
-        environ['CACHE_URL'] = 'redis://127.0.0.1:6379/0/prefix'
+        environ['CACHE_URL'] = 'redis://127.0.0.1:6379:0?key_prefix=site1'
 
     def test_redis_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -125,13 +125,13 @@ class TestRedisCache(Base):
 
     def test_redis_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], 'prefix')
+        assert_equals(config['KEY_PREFIX'], 'site1')
 
 
 class TestHiredisCache(Base):
     def setUp(self):
         super(TestHiredisCache, self).setUp()
-        environ['CACHE_URL'] = 'hiredis://127.0.0.1:6379/0/prefix'
+        environ['CACHE_URL'] = 'hiredis://127.0.0.1:6379:0?key_prefix=site1'
 
     def test_hiredis_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -144,7 +144,7 @@ class TestHiredisCache(Base):
 
     def test_hiredis_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], 'prefix')
+        assert_equals(config['KEY_PREFIX'], 'site1')
 
     def test_hiredis_url_sets_hiredis_parser(self):
         config = django_cache_url.config()
@@ -155,7 +155,7 @@ class TestHiredisCache(Base):
 class TestRedisCacheWithPassword(Base):
     def setUp(self):
         super(TestRedisCacheWithPassword, self).setUp()
-        environ['CACHE_URL'] = 'redis://:redispass@127.0.0.1:6379/0/prefix'
+        environ['CACHE_URL'] = 'redis://:redispass@127.0.0.1:6379:0?key_prefix=site1'
 
     def test_redis_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -168,7 +168,7 @@ class TestRedisCacheWithPassword(Base):
 
     def test_redis_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], 'prefix')
+        assert_equals(config['KEY_PREFIX'], 'site1')
 
     def test_redis_url_returns_password(self):
         config = django_cache_url.config()
@@ -180,7 +180,7 @@ class TestRedisCacheWithPassword(Base):
 class TestRedisBothSocketCache(Base):
     def setUp(self):
         super(TestRedisBothSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'redis://unix/path/to/socket/file.sock/1/prefix'
+        environ['CACHE_URL'] = 'redis:///path/to/socket:1?key_prefix=site1'
 
     def test_socket_url_returns_redis_cache(self):
         location = 'redis_cache.cache.RedisCache'
@@ -189,41 +189,41 @@ class TestRedisBothSocketCache(Base):
 
     def test_socket_url_returns_location_and_port_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['LOCATION'], 'unix:/path/to/socket/file.sock:1')
+        assert_equals(config['LOCATION'], 'unix:/path/to/socket:1')
 
     def test_socket_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], 'prefix')
+        assert_equals(config['KEY_PREFIX'], 'site1')
 
 
 class TestRedisDatabaseSocketCache(TestRedisBothSocketCache):
     def setUp(self):
         super(TestRedisDatabaseSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'redis://unix/path/to/socket/file.sock/1'
+        environ['CACHE_URL'] = 'redis:///path/to/socket:1'
 
     def test_socket_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], '')
+        assert_equals(config.get('KEY_PREFIX'), None)
 
 
 class TestRedisPrefixSocketCache(TestRedisBothSocketCache):
     def setUp(self):
         super(TestRedisPrefixSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'redis://unix/path/to/socket/file.sock/prefix'
+        environ['CACHE_URL'] = 'redis:///path/to/socket?key_prefix=site1'
 
     def test_socket_url_returns_location_and_port_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['LOCATION'], 'unix:/path/to/socket/file.sock:0')
+        assert_equals(config['LOCATION'], 'unix:/path/to/socket:0')
 
     def test_socket_url_returns_prefix_from_url(self):
         config = django_cache_url.config()
-        assert_equals(config['KEY_PREFIX'], 'prefix')
+        assert_equals(config['KEY_PREFIX'], 'site1')
 
 
 class TestHiredisDatabaseSocketCache(TestRedisDatabaseSocketCache):
     def setUp(self):
         super(TestHiredisDatabaseSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'hiredis://unix/path/to/socket/file.sock/1'
+        environ['CACHE_URL'] = 'hiredis:///path/to/socket:1'
 
     def test_hiredis_url_sets_hiredis_parser(self):
         config = django_cache_url.config()
@@ -234,7 +234,7 @@ class TestHiredisDatabaseSocketCache(TestRedisDatabaseSocketCache):
 class TestHiredisPrefixSocketCache(TestRedisPrefixSocketCache):
     def setUp(self):
         super(TestHiredisPrefixSocketCache, self).setUp()
-        environ['CACHE_URL'] = 'hiredis://unix/path/to/socket/file.sock/prefix'
+        environ['CACHE_URL'] = 'hiredis:///path/to/socket?key_prefix=site1'
 
     def test_hiredis_url_sets_hiredis_parser(self):
         config = django_cache_url.config()


### PR DESCRIPTION
Uses standard url schema for sockets, querystring to allow for cache
arguments and an optional redis database url component.

Related to ghickman/django-cache-url#16 and ghickman/django-cache-url#14

I broke backwards compatibility so I'm not sure whether you'll want to accept this. I wrote it after noticing that the Heroku RedisToGo urls that I was getting were `redis://user:pass@jack.redistogo.com:10364/` - notice no db number is specified so the existing parsing broke.

I think there are a few problems with the existing url schema though as alluded to in the referenced issues:
* When specifying a socket, the url is not a standard file url. The current parsing also relies on the socket name ending in `.sock` or `.socket`.
* For redis, what I already said about the database not necessarily being specified and needing to be optional. Using the `redis://host:port/db[/prefix]` format doesn't make much sense since db and prefix are not subordinate resources and writing parsing code to match the format is cumbersome. I think the format of optionally specifying the database as `redis://host:port:db` makes much more sense and also matches the format of the django-redis location field.
* It's not possible to pass cache arguments, using the query string seems like a good candidate for this.