### PR TITLE
django-redis >= 4.5.0 support

### DIFF
--- a/django_cache_url.py
+++ b/django_cache_url.py
@@ -97,7 +97,7 @@ def parse(url):
                 redis_options['PASSWORD'] = url.password
             # Specifying the database is optional, use db 0 if not specified.
             db = path[1:] or '0'
-            config['LOCATION'] = "%s:%s:%s" % (url.hostname, url.port, db)
+            config['LOCATION'] = "redis://%s:%s:%s" % (url.hostname, url.port, db)
 
     if redis_options:
         config.setdefault('OPTIONS', {}).update(redis_options)

--- a/tests/test_config_options.py
+++ b/tests/test_config_options.py
@@ -23,4 +23,4 @@ def test_setting_env_var():
     config = django_cache_url.config()
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == '127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -10,7 +10,7 @@ def test_hiredis():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == '127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
@@ -32,7 +32,7 @@ def test_redis():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == '127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
 
 
 def test_redis_socket():
@@ -49,5 +49,5 @@ def test_redis_with_password():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == '127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'


### PR DESCRIPTION
django-redis removed support of old url format in https://github.com/niwinz/django-redis/commit/7cf3939ca80c518a09bcc8ae3bd758e3e8ba6d34