### PR TITLE
Use / to separate Redis port and db index

### DIFF
--- a/django_cache_url.py
+++ b/django_cache_url.py
@@ -97,7 +97,7 @@ def parse(url):
                 redis_options['PASSWORD'] = url.password
             # Specifying the database is optional, use db 0 if not specified.
             db = path[1:] or '0'
-            config['LOCATION'] = "redis://%s:%s:%s" % (url.hostname, url.port, db)
+            config['LOCATION'] = "redis://%s:%s/%s" % (url.hostname, url.port, db)
 
     if redis_options:
         config.setdefault('OPTIONS', {}).update(redis_options)

--- a/tests/test_config_options.py
+++ b/tests/test_config_options.py
@@ -23,4 +23,4 @@ def test_setting_env_var():
     config = django_cache_url.config()
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -10,7 +10,7 @@ def test_hiredis():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
@@ -32,7 +32,7 @@ def test_redis():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
 
 
 def test_redis_socket():
@@ -49,5 +49,5 @@ def test_redis_with_password():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
-    assert config['LOCATION'] == 'redis://127.0.0.1:6379:0'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'


### PR DESCRIPTION
Redis parsing is not working right now with the error message `invalid literal for int() with base 10: '6379:0'`

It seems that, as django_redis no longer parse the connection URL, this duty is now in the redis library, which use urllib to parse.

django-cache-url emits url with the format `redis://host:port:db` which will make urllib tries to parse `port:db` as the port and fail.

This patch will separate port and db with `/`, so the new URL will be `redis://host:port/db` [accordingly to the docs](https://niwinz.github.io/django-redis/latest/#_configure_as_cache_backend)