### PR TITLE
Adds support for django-redis version >=3.8.0 unix:// locations

### DIFF
--- a/django_cache_url.py
+++ b/django_cache_url.py
@@ -103,7 +103,15 @@ def parse(url):
                     path = path[:path.rfind('/')]
                 else:
                     db = '0'
-                config['LOCATION'].append('unix:%s:%s' % (path, db))
+
+                unix_db_separator = ':'
+                try:
+                    import django_redis
+                    if django_redis.VERSION >= (3, 8):
+                        unix_db_separator = '?db='
+                except (ImportError, AttributeError):
+                    pass
+                config['LOCATION'].append('unix:%s%s%s' % (path, unix_db_separator, db))
             else:
                 config['LOCATION'].append(path)
 

--- a/django_cache_url.py
+++ b/django_cache_url.py
@@ -125,6 +125,8 @@ def parse(url):
     # Single location may be set not as a list
     if len(config['LOCATION']) == 1 and isinstance(config['LOCATION'], list):
         config['LOCATION'] = config['LOCATION'][0]
+
+    # Memcache likes it in one line.
     elif url.scheme in ('memcached', 'pymemcached', 'djangopylibmc'):
         config['LOCATION'] = ';'.join(config['LOCATION'])
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -51,3 +51,38 @@ def test_redis_with_password():
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'
+
+
+def test_redis_multiple():
+    url = 'redis://127.0.0.1:6379/0,127.0.0.2:6379/1?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == ['redis://127.0.0.1:6379/0',
+                                  'redis://127.0.0.2:6379/1']
+
+
+def test_redis_multiple_socket():
+    url = 'redis:///path/to/socket/1,/path/to/other_socket/2?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == ['unix:/path/to/socket:1',
+                                  'unix:/path/to/other_socket:2']
+    assert 'OPTIONS' not in config
+
+
+def test_redis_multiple_mixed():
+    url = 'redis://127.0.0.1:6379/0,/path/to/socket/1?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == ['redis://127.0.0.1:6379/0',
+                                  'unix:/path/to/socket:1']
+
+    url = 'redis:///path/to/socket/1,127.0.0.1:6379/0?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == ['unix:/path/to/socket:1',
+                                  'redis://127.0.0.1:6379/0']


### PR DESCRIPTION
Made over #31. Please ask if needed a pure one over ``master``. Should be a 8-line patch starting on ``unix_db_separator``.